### PR TITLE
using local embedder

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ func main() {
 
 ### Create a new vector store
 
+Here we are using pinecone, but there is `heisenberg` that can run locally
+
 ```go
 package main
 
@@ -71,22 +73,24 @@ func main() {
 
 ### Example of using Memory
 
+This example will show how to use the default sqlite store, heisenberg, and possibly the local embedder
+
 ```go
 package main
 
 import (
-        "fmt"
-        "github.com/aldarisbm/memory"
-        oai "github.com/aldarisbm/memory/embeddings/openai"
-        "github.com/aldarisbm/memory/vectorstore/heisenberg"
-        "os"
+	"fmt"
+	"github.com/aldarisbm/memory"
+	"github.com/aldarisbm/memory/embeddings/local"
+	"github.com/aldarisbm/memory/vectorstore/heisenberg"
+	"os"
+	"time"
 )
 
 func main() {
-	emb := oai.NewOpenAIEmbedder(
-		oai.WithApiKey(os.Getenv("OPENAI_API_KEY")),
-	)
-
+	// for this to work you should be running something like
+	// https://github.com/aldarisbm/sentence_transformers locally
+	emb := local.New(local.WithHost("http://127.0.0.1:5000"))
 	// Uses default SQLite for storage
 	// And default Heisenberg for vector store
 	mem := memory.NewMemory(memory.WithEmbedder(emb))
@@ -121,7 +125,7 @@ func main() {
 	// the office is a good comedy show
 	// Black Mirror is a suspenseful show
 	// If we are talking about suspenseful shows, then Twilight Zone is the best
-	
+
 	// the last one being the closest to the query
 }
 ```

--- a/embeddings/local/local.go
+++ b/embeddings/local/local.go
@@ -22,6 +22,9 @@ type embedder struct {
 	client            *http.Client
 }
 
+// New returns a new embedder that uses a local server to embed text
+// The local server should be running the following code for it to work properly:
+// https://github.com/aldarisbm/sentence_transformers
 func New(opts ...CallOptions) *embedder {
 	o := applyCallOptions(opts, options{
 		host:              "http://localhost:5000",

--- a/embeddings/local/local.go
+++ b/embeddings/local/local.go
@@ -1,0 +1,75 @@
+package local
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/aldarisbm/memory/embeddings"
+	"net/http"
+)
+
+type request struct {
+	Text string `json:"text"`
+}
+
+type response struct {
+	Embedding []float32 `json:"embedding"`
+}
+
+type embedder struct {
+	host              string
+	embeddingEndpoint string
+	client            *http.Client
+}
+
+func New(opts ...CallOptions) *embedder {
+	o := applyCallOptions(opts, options{
+		host:              "http://localhost:5000",
+		embeddingEndpoint: "/embeddings",
+	})
+	return &embedder{
+		host:              o.host,
+		embeddingEndpoint: o.embeddingEndpoint,
+		client:            &http.Client{},
+	}
+}
+func (e embedder) EmbedDocumentText(text string) ([]float32, error) {
+	req := request{
+		Text: text,
+	}
+	b, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := fmt.Sprintf(e.host + e.embeddingEndpoint)
+	resp, err := e.client.Post(endpoint, "application/json", bytes.NewBuffer(b))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var r response
+	err = json.NewDecoder(resp.Body).Decode(&r)
+
+	return r.Embedding, nil
+}
+
+func (e embedder) EmbedDocumentTexts(texts []string) ([][]float32, error) {
+	// should make this better but for now, to loop over the texts
+	// and call EmbedDocumentText
+	embs := make([][]float32, len(texts))
+	for _, text := range texts {
+		emb, err := e.EmbedDocumentText(text)
+		if err != nil {
+			return nil, err
+		}
+		embs = append(embs, emb)
+	}
+	return embs, nil
+}
+
+func (e embedder) GetDimensions() uint {
+	const SentenceTransformersDimensions = 384
+	return SentenceTransformersDimensions
+}
+
+var _ embeddings.Embedder = (*embedder)(nil)

--- a/embeddings/local/options.go
+++ b/embeddings/local/options.go
@@ -1,0 +1,40 @@
+package local
+
+type options struct {
+	host              string
+	embeddingEndpoint string
+}
+
+type CallOptions struct {
+	applyFunc func(o *options)
+}
+
+func applyCallOptions(callOptions []CallOptions, defaultOptions ...options) *options {
+	o := new(options)
+	if len(defaultOptions) > 0 {
+		*o = defaultOptions[0]
+	}
+
+	for _, callOption := range callOptions {
+		callOption.applyFunc(o)
+	}
+
+	return o
+}
+
+// WithHost sets the host for the Embedder.
+func WithHost(host string) CallOptions {
+	return CallOptions{
+		applyFunc: func(o *options) {
+			o.host = host
+		},
+	}
+}
+
+func WithEmbeddingEndpoint(endpoint string) CallOptions {
+	return CallOptions{
+		applyFunc: func(o *options) {
+			o.embeddingEndpoint = endpoint
+		},
+	}
+}


### PR DESCRIPTION
this uses a embedder at `localhost` with an endpoint `embeddings`

It's very simple but expects a simple API  eg:

REQ with content type `application/json` by default:

```
{ "text" : "my text to embed" }
```

RESP:
```
{ "embedding": [0.0, 0.2, 0.3] }
```
